### PR TITLE
Export RSWT and WriterT constructor

### DIFF
--- a/src/Control/Monad/RWS/CPS.hs
+++ b/src/Control/Monad/RWS/CPS.hs
@@ -33,7 +33,7 @@ module Control.Monad.RWS.CPS (
   mapRWS,
   withRWS,
   -- * The RWST monad transformer
-  RWST,
+  RWST(..),
   runRWST,
   evalRWST,
   execRWST,

--- a/src/Control/Monad/Writer/CPS.hs
+++ b/src/Control/Monad/Writer/CPS.hs
@@ -30,7 +30,7 @@ module Control.Monad.Writer.CPS (
   execWriter,
   mapWriter,
   -- * The WriterT monad transformer
-  WriterT,
+  WriterT(..),
   runWriterT,
   execWriterT,
   mapWriterT,

--- a/writer-cps-mtl.cabal
+++ b/writer-cps-mtl.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           writer-cps-mtl
-version:        0.1.1.0
+version:        0.1.1.1
 cabal-version:  >= 1.10
 license:        BSD3
 license-file:   LICENSE


### PR DESCRIPTION
Hi, thanks for creating this package, but I couldn't use it because the constructor isn't exported.
I think they are supposed to be exported. See

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.RWS.Strict.html

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.Writer.Strict.html